### PR TITLE
Dr. Francesca Gandini Student Research Summer 2025

### DIFF
--- a/InvariantRing/AbelianGroups.m2
+++ b/InvariantRing/AbelianGroups.m2
@@ -7,70 +7,91 @@
    the License, or any later version.
 *-
 
-
-DiagonalAction = new Type of GroupAction
-
--------------------------------------------
---- DiagonalAction methods -------------------
 -------------------------------------------
 
-diagonalAction = method()
+DiagonalAction = new Type of GroupAction    -- the DiagonalAction object
 
+diagonalAction = method()                   -- Constructor for DiagonalAction object
+
+-------------------------------------------
+--- DiagonalAction Constructors -----------
+-------------------------------------------
+
+-------------------------------
+---- diagonalAction constructor
+-->-    W1 & W2 - Weight matricies
+-->-    g       - Order of the group
+-->-    R       - Ring
 diagonalAction (Matrix, Matrix, List, PolynomialRing) := DiagonalAction => (W1, W2, d, R) -> (
+    --!-- Ensures inputs are valid --!--
     if not isField coefficientRing R then (
-	error "diagonalAction: Expected the last argument to be a polynomial ring over a field."
+	    error "diagonalAction: Expected the last argument to be a polynomial ring over a field."
 	);
     if ring W1 =!= ZZ or ring W2 =!= ZZ then (
-	error "diagonalAction: Expected the first and second arguments to be matrices of integer weights."
+	    error "diagonalAction: Expected the first and second arguments to be matrices of integer weights."
 	);
     if numColumns W1 =!= dim R or numColumns W2 =!= dim R then (
-	error "diagonalAction: Expected the number of columns of each matrix to equal the dimension of the polynomial ring."
+	    error "diagonalAction: Expected the number of columns of each matrix to equal the dimension of the polynomial ring."
 	);
     if numRows W2 =!= #d then (
-	error "diagonalAction: Expected the number of rows of the second argument to equal the size of the list."
+	    error "diagonalAction: Expected the number of rows of the second argument to equal the size of the list."
 	);
     if any(d, j -> not instance(j, ZZ) or j <= 0) then (
-	error "diagonalAction: Expected the second argument to be a list of positive integers."
+	    error "diagonalAction: Expected the second argument to be a list of positive integers."
 	);
     p := char R;
     if p > 0 and any(d, j -> j%p == 0) then (
-	error "diagonalAction: Diagonal action is not defined when the characteristic divides the order of one of the cyclic factors."
-	);    
+	    error "diagonalAction: Diagonal action is not defined when the characteristic divides the order of one of the cyclic factors."
+	); 
+    --!-- ---------------------- --!--
+    ----- - Creates the object - --!--
     r := numRows W1;
     g := numRows W2;
-    z := getSymbol "z";
-    C := ZZ[Variables=> r + g,VariableBaseName=>z,
-	MonomialOrder=> {GroupLex => r,GroupLex => g},
-	Inverses=>true];
+    diagVariable := getSymbol "diagVariable";
+    C := ZZ[Variables           => r + g,
+            VariableBaseName    => diagVariable,
+	        MonomialOrder       => {GroupLex => r,GroupLex => g},
+	        Inverses            => true];
     new DiagonalAction from {
-	cache => new CacheTable,
-	(symbol cyclicFactors) => d,
-	(symbol degreesRing) => C monoid degreesRing R,
-	(symbol numgens) => g, 
-	(symbol ring) => R, 
-	(symbol rank) => r,
-	(symbol weights) => (W1, W2)
+        cache => new MutableHashTable,
+        (symbol cyclicFactors) => d,
+        (symbol degreesRing) => C monoid degreesRing R,
+        (symbol numgens) => g, 
+        (symbol ring) => R, 
+        (symbol rank) => r,
+        (symbol weights) => (W1, W2)
 	}
-    )
+)
 
+-------------------------------
+---- diagonalAction constructor
+-->-    W       - Weight matricies
+-->-    g       - Order of the group
+-->-    R       - Ring
 diagonalAction (Matrix, List, PolynomialRing) := DiagonalAction => (W, d, R) -> (
     if ring W =!= ZZ then (
-	error "diagonalAction: Expected the first argument to be a matrix of integer weights."
+	    error "diagonalAction: Expected the first argument to be a matrix of integer weights."
 	);
     r := numRows W - #d;
     if r < 0 then (
-	error "diagonalAction: The number of rows of the matrix cannot be smaller than the size of the list."
+	    error "diagonalAction: The number of rows of the matrix cannot be smaller than the size of the list."
 	); 
     W1 := W^(apply(r, i -> i));
     W2 := W^(apply(#d, i -> r + i));
     diagonalAction(W1, W2, d, R)
-    )
+)
 
-diagonalAction (Matrix, PolynomialRing) := DiagonalAction => (W, R) -> diagonalAction(W, {}, R)
-
+---- Additional constructors when parameters have special properties
+diagonalAction (Matrix, PolynomialRing)     := DiagonalAction => (W, R)     -> diagonalAction(W, {}, R)
+diagonalAction (Matrix, ZZ, PolynomialRing) := DiagonalAction => (W, z, R)  -> diagonalAction(W, apply(numRows W, i -> z), R)
 
 -------------------------------------------
+--- DiagonalAction Methods ----------------
+-------------------------------------------
 
+-------------------------------
+---- net DiagonalAction
+-->-    Used to print out a diagonalAction object
 net DiagonalAction := D -> (
     torus := "";
     cyclicGroups := "";
@@ -78,54 +99,65 @@ net DiagonalAction := D -> (
     g := D.numgens;
     local weightMatrix;
     if r > 0 then (
-	torus = (expression coefficientRing D.ring)^(expression "*");
-	if r > 1 then torus = (expression ("("|net torus|")"))^(expression r)
-	);
+        torus = (expression coefficientRing D.ring)^(expression "*");
+	    if r > 1 then (
+            torus = (expression ("("|net torus|")"))^(expression r)
+        );
+    );
     if g > 0 then (
-	cyclicGroups = cyclicGroups|horizontalJoin apply(g, i -> (
-		if i == g - 1 then (net ZZ|"/"|net D.cyclicFactors#i)
-		else (net ZZ|"/"|net D.cyclicFactors#i|" x ")
-		)
+	    cyclicGroups = cyclicGroups|horizontalJoin apply(g, i -> 
+            (   if i == g - 1 then (net ZZ|"/"|net D.cyclicFactors#i)
+                else (net ZZ|"/"|net D.cyclicFactors#i|" x ")
+		    )
 	    );
-	if r > 0 then (
-	    torus = net torus|" x ";
-	    weightMatrix = D.weights
-	    )
-	else weightMatrix = last D.weights
+        if r > 0 then (
+            torus = net torus|" x ";
+            weightMatrix = D.weights
+        )
+        else weightMatrix = last D.weights;
 	)
     else weightMatrix = first D.weights;
     stack {(net D.ring)|" <- "|net torus|net cyclicGroups|" via ","", net weightMatrix}
-    )
+)
 
+
+---- cyclicFactors
+-->- Method to access the cyclicFactors of a DiagonalAction
 cyclicFactors = method()
-
 cyclicFactors DiagonalAction := List => D -> D.cyclicFactors
 
+
+-->- Override of "degreesRing" function for DiagonalAction
 degreesRing DiagonalAction := Ring => D -> D.degreesRing
 
+-->- Override for "numgens" function for DiagonalAction
 numgens DiagonalAction := ZZ => D -> D.numgens
 
+-->- Override for "rank" function for DiagonalAction
 rank DiagonalAction := ZZ => D -> D.rank
 
+---- weights
+-->- Method to access the cyclicFactors of a DiagonalAction
 weights = method()
-
 weights DiagonalAction := Matrix => D -> D.weights
 
 
+-------------------------------------------
+--- Equivariant Hilbert Series Methods ----
+-------------------------------------------
 
 equivariantHilbertSeries = method(Options => {Order => infinity}, TypicalValue => Divide)
 
 equivariantHilbertSeries DiagonalAction := op -> T -> (
-    if unique degrees ring T =!= {{1}} then
-    error "Only implemented for standard graded polynomial rings";
+    if unique degrees ring T =!= {{1}} then error "Only implemented for standard graded polynomial rings";
     ord := op.Order;
     if ord === infinity then (
-	equivariantHilbertRational(T)
+	    equivariantHilbertRational(T)
 	)
     else (
-	equivariantHilbertPartial(T,ord-1)
-	)
-    )
+	    equivariantHilbertPartial(T,ord-1)
+	);
+)
 
 -- computes equivariant hilbert series as rational function
 -- INPUT: T, DiagonalAction
@@ -136,7 +168,7 @@ equivariantHilbertRational = T -> (
     d := cyclicFactors T;
     if not zero W2 then (
     	W2 = matrix apply(entries W2,d,(row,m)->apply(row,i->i%m));
-    	);
+    );
     W := W1 || W2;
     R := degreesRing T;
     C := coefficientRing R;
@@ -149,40 +181,40 @@ equivariantHilbertRational = T -> (
 -- INPUT: T, DiagonalAction
 equivariantHilbertPartial = (T, d) -> (
     if not T.cache.?equivariantHilbert then (
-	T.cache.equivariantHilbert = 1_(degreesRing T);
+	    T.cache.equivariantHilbert = 1_(degreesRing T);
 	);
     currentDeg := first degree T.cache.equivariantHilbert;
     (M,C) := coefficients T.cache.equivariantHilbert;
     if (d > currentDeg) then (
-	R := degreesRing T;
-	r := rank T;
-	g := numgens T;
-	cf := cyclicFactors T;
-    	den := value denominator equivariantHilbertSeries T;
-    	denDeg := first degree den;
-	B := last coefficients den;
-	if cf =!= {} then (
-	    CR := coefficientRing R;
-	    phi := map(CR,R);
-	    CRab := ZZ[Variables=>g];
-	    CRab = CRab / ideal apply(g,i -> CRab_i^(cf_i)-1);
-	    psi := map(CRab,CR,toList(r:1)|(gens CRab));
-	    psi' := map(CR,CRab,apply(g, i-> CR_(r+i)));
-      	    (m,c) := coefficients(phi B,Variables=>apply(g, i-> CR_(r+i)));
-	    m = psi' psi m;
-	    B = m*c;
-	    );
-	for i from currentDeg+1 to d do (
-	    p := -sum(1..min(i,denDeg),k -> C_(i-k,0)*B_(k,0) );
-	    if cf =!= {} then (
-	    	(m,c) = coefficients(phi p,Variables=>apply(g, i-> CR_(r+i)));
-	    	m = psi' psi m;
-	    	p = (m*c)_(0,0);
-	    	);
-	    M = M | matrix{{R_0^i}};
-	    C = C || matrix{{p}};
-	    );
+        R := degreesRing T;
+        r := rank T;
+        g := numgens T;
+        cf := cyclicFactors T;
+            den := value denominator equivariantHilbertSeries T;
+            denDeg := first degree den;
+        B := last coefficients den;
+        if cf =!= {} then (
+            CR := coefficientRing R;
+            phi := map(CR,R);
+            CRab := ZZ[Variables=>g];
+            CRab = CRab / ideal apply(g,i -> CRab_i^(cf_i)-1);
+            psi := map(CRab,CR,toList(r:1)|(gens CRab));
+            psi' := map(CR,CRab,apply(g, i-> CR_(r+i)));
+            (m,c) := coefficients(phi B,Variables=>apply(g, i-> CR_(r+i)));
+            m = psi' psi m;
+            B = m*c;
+        );
+        for i from currentDeg+1 to d do (
+            p := -sum(1..min(i,denDeg),k -> C_(i-k,0)*B_(k,0) );
+            if cf =!= {} then (
+                (m,c) = coefficients(phi p,Variables=>apply(g, i-> CR_(r+i)));
+                m = psi' psi m;
+                p = (m*c)_(0,0);
+            );
+            M = M | matrix{{R_0^i}};
+            C = C || matrix{{p}};
+        );
 	);
     q := first flatten entries (M_{0..d}*C^{0..d});
     T.cache.equivariantHilbert = q
-    )
+)

--- a/InvariantRing/AbelianGroupsDoc.m2
+++ b/InvariantRing/AbelianGroupsDoc.m2
@@ -11,15 +11,17 @@
 document {
 	Key => {diagonalAction, 
 	    (diagonalAction, Matrix, PolynomialRing),
+		(diagonalAction, Matrix, ZZ, PolynomialRing),
 	    (diagonalAction, Matrix, List, PolynomialRing),
 	    (diagonalAction, Matrix, Matrix, List, PolynomialRing)
 	    },
 	Headline => "diagonal group action via weights",
-	Usage => "diagonalAction(W, R), diagonalAction(W, d, R), diagonalAction(W1, W2, d, R)",
+	Usage => "diagonalAction(W, R), diagonalAction(W, z, R), diagonalAction(W, d, R), diagonalAction(W1, W2, d, R)",
 	Inputs => {
 	    	"W" => Matrix => {"of weights of the diagonal group action"},
 		"W1" => Matrix => {"of weights for the torus action"},
 		"W2" => Matrix => {"of weights for the finite abelian action"},
+		"z" => ZZ => {"of the order of an elementary abelian group"},
 	    	"d" => List => {"of orders of cyclic abelian factors in the 
 		    decomposition of the diagonal group"},
 		"R" => PolynomialRing => {"on which the group acts"}
@@ -67,8 +69,8 @@ document {
 	    },
         	
 	EXAMPLE {
-	    "R = QQ[x_1..x_4]",
-	    "W = matrix{{0,1,-1,1},{1,0,-1,-1}}",
+	    "R = QQ[x_1..x_4];",
+	    "W = matrix{{0,1,-1,1},{1,0,-1,-1}};",
 	    "T = diagonalAction(W, R)"
 		},
 	    
@@ -78,13 +80,14 @@ document {
 	    },
 	
 	EXAMPLE {
-	    "R = QQ[x_1..x_3]",
-	    "d = {3,3}",
-	    "W = matrix{{1,0,1},{0,1,1}}",
-	    "A = diagonalAction(W, d, R)",
-		},
+	    "R = QQ[x_1..x_3];",
+	    "d = {2,5}; z = 3;",
+	    "W = matrix{{1,0,1},{0,1,1}};",
+		"A = diagonalAction(W, d, R)",
+		"B = diagonalAction(W, z, R)"
+		}
     
-	    }
+}
 
 document {
 	Key => {DiagonalAction},

--- a/InvariantRing/Invariants.m2
+++ b/InvariantRing/Invariants.m2
@@ -111,119 +111,236 @@ reynoldsOperator (RingElement, DiagonalAction) := RingElement => (f, D) -> sum s
 
 -------------------------------------------
 
+-------------------------------------------
+--- Elementary Invariants Methods ---------
+-------------------------------------------
+
+-- Checks if a list is completely 0
+isZero := L -> (
+    for i in L do if (i != 0) then return false;
+    return true;
+)
+-- Reduces a monomial by all other monomials in a list. 
+-- Returns: 1 if it is to be removed
+--          2 if it is minimal and can't be removed
+reduceit := (l, L) -> (
+    for a in L do (
+        if (a == l) then return 1;
+        killit := true;
+        for i to #a - 1 do if (l#i < a#i) then killit = false;
+        if killit then (
+            l = l - a;
+            if isZero(l) then return 1;
+        );
+    );
+    return 2;
+)
+-- Checks if a given seed is minimal.
+-- Returns: 0 if m is not minimal
+--          1 if l is not minimal
+--          2 if m is minimal
+seedminimal := (m, L) -> (
+    for l to #L-1 do (
+        mmin := true;
+        lmin := true;
+        for i to #m - 1 when (mmin or lmin) do (
+            if (m_i > L#l_i) then mmin = false;
+            if (L#l_i > m_i) then lmin = false;
+        );
+        if lmin then return 0;
+        if mmin then return reduceit(L#l - m, L);
+    );
+    return 2;
+)
+
+-->-- Method for p x p group with representative weight matrix --<--
+elementaryInvariants := D -> (
+    
+    W := D.weights_1;
+    d := (D.cyclicFactors)#0;
+    R := ring D;
+    --------------------------
+    -->-- generate seeds --<--
+    n := numColumns W; m := numRows W;
+    -->-- find submatrix with nonzero determinant --<--
+    subVars := matrix{{0}}; colList := {};
+    mList := toList (0..(m-1));
+    for i to n - m do (
+        rod := submatrix(W, mList, toList (i..(i + m - 1)));
+        if (determinant rod != 0) then (
+            subVars = rod;
+            colList = toList (i..(i + m - 1));
+            break;
+        );
+    );
+    -->-- return error if no nonzero submatrix determinant exists --<--
+    if (subVars == matrix{{0}}) then (
+        error ("No invariants for this weight matrix.\n");
+        return {};
+    );
+    seedList := {};
+    -->-- Creates all the representative exponent vectors in accordance with the algorithm --<--
+    for v in toList(set(toList (0..(n-1))) - set(colList)) do (
+        wColumns := sort({v} | colList); tempVec := {}; signFlip := 1;
+        for i in wColumns do (
+            e := for j from 0 to n-1 list (if j == i then 1 else 0);
+            subM := submatrix(W, mList, sort(toList(set(wColumns) - set({i}))));
+            tempVec = tempVec | {signFlip * (determinant subM) * e};
+            signFlip = signFlip * -1;
+        );
+        seedList = seedList | {sum tempVec};
+    );
+    ------------------------
+    -->-- expand seeds --<--
+    gR := gens R;
+    ind := numgens R - 1;
+    seedList = for l in seedList list apply(l, x -> ((x % d) + d) % d);
+    newList := seedList;
+    trashList := seedList | {apply(ind + 1, i -> 0)};
+    -->-- Expands each of the seeds in accordance with the representative exponent vectors --<--
+    -->-- The monomials are represented via their exponent vectors as lists in m2 --<--
+    for i from 1 to (d) do (
+            for m when m < #newList do (       
+            for n to #newList - 1 do (
+                m' := (newList#m)*i;
+                n' := newList#n;
+                m' = (m' + n') % d;
+                if (not isZero(m')) and (not any(trashList, t -> (m' == t))) then (
+                    result := seedminimal(m', newList);
+                    if (result == 1) then (
+                        newList = replace(n, m', newList);
+                        m = m - 1;
+                    )
+                    else if (result == 2) then newList = newList | {m'}
+                    else trashList = trashList | {m'};
+                );
+            );
+        );
+    );
+    -->-- Then, we add the pure powers to the list --<--
+    for i from 0 to (numgens R - 1) do (
+        newList = newList | {for k to numgens R - 1 list (if i == k then d else 0)};
+    );
+    polyList := {};
+    -->-- Then, we turn each of the exponent vectors into their polynomials in the Ring --<--
+    for i in newList do (
+        n := 1;
+        for j to #i - 1 do (n = n * (((gens R)_j)^(i_j)));
+        polyList = polyList | {n};
+    );
+
+    return sort polyList;
+)
+
+-------------------------------------------
+--- invariants for DiagonalAction ---------
+-------------------------------------------
+
 invariants = method(Options => {
 	Strategy => "Default",
 	UseCoefficientRing => false,
 	DegreeBound => infinity,
 	DegreeLimit => {},
 	SubringLimit => infinity
-	})
+	}
+)
 
 invariants DiagonalAction := List => o -> D -> (
+    d := cyclicFactors D;
+    --*-* If elementary, then use elementary generation method *-*--
+    if (o.Strategy == "Default") and all(D.cyclicFactors, i -> D.cyclicFactors#0 == i) then return elementaryInvariants D;
+    --*-* Otherwise, continue with regular method *-*--
     (W1, W2) := weights D;
     R := ring D;
     kk := coefficientRing R;
     p := char kk;
-    d := cyclicFactors D;
     r := rank D;
     if p > 0 and o.UseCoefficientRing then (
-	q := kk#order;
-	if any(d, j -> q%j =!= 1) then (
-	    print "-- Diagonal action is not defined over the given coefficient ring. \n-- Returning invariants over an infinite extension field over which the action is defined."
-	    )
-	else (
-	    D' := diagonalAction(W1||W2, apply(r, i -> q - 1)|d, R);
-	    return invariants D'
-	    )
-    	);
+        q := kk#order;
+        if any(d, j -> q%j =!= 1) then (
+            print "-- Diagonal action is not defined over the given coefficient ring. \n-- Returning invariants over an infinite extension field over which the action is defined.";
+        )
+        else (
+            D' := diagonalAction(W1||W2, apply(r, i -> q - 1)|d, R);
+            return invariants D';
+        )
+    );
     R = kk[R_*, MonomialOrder => GLex];
     g := numgens D;
     n := dim D;
     mons := R_*;
     local C, local S, local U;
     local v, local m, local v', local u;
-    
     if g > 0 then (
-	t := product d;
-	
-	reduceWeight := w -> vector apply(g, i -> w_i%d#i);
-	
-	C = apply(n, i -> reduceWeight W2_i);
-	
-	S = new MutableHashTable from apply(C, w -> w => {});
-	scan(#mons, i -> S#(reduceWeight W2_i) = S#(reduceWeight W2_i)|{mons#i});
-	U = R_*;
-	
-	while  #U > 0 do(
-	    m = min U; 
-	    v = first exponents m;
-	    k := max positions(v, i -> i > 0);
-	    v = reduceWeight(W2*(vector v));
-	    
-	    while k < n do(
-	    	u = m*R_k;
-	    	v' = reduceWeight(v + W2_k);
-	    	if (not S#?v') then S#v' = {};
-	    	if all(S#v', m' -> u%m' =!= 0_R) then (
-		    S#v' = S#v'|{u};
-		    if first degree u < t then U = U | {u}
-		    );
-	    	k = k + 1;
-	    	);
-	    U = delete(m, U);
-	    );
-    	if S#?(0_(ZZ^g)) then mons = S#(0_(ZZ^g)) else mons = {}
-    	);
+        t := product d;
+        reduceWeight := w -> vector apply(g, i -> w_i%d#i);
+        C = apply(n, i -> reduceWeight W2_i);
+        S = new MutableHashTable from apply(C, w -> w => {});
+        scan(#mons, i -> S#(reduceWeight W2_i) = S#(reduceWeight W2_i)|{mons#i});
+        U = R_*;
+        while  #U > 0 do(
+            m = min U; 
+            v = first exponents m;
+            k := max positions(v, i -> i > 0);
+            v = reduceWeight(W2*(vector v));
+            while k < n do(
+                u = m*R_k;
+                v' = reduceWeight(v + W2_k);
+                if (not S#?v') then S#v' = {};
+                if all(S#v', m' -> u%m' =!= 0_R) then (
+                    S#v' = S#v'|{u};
+                    if first degree u < t then U = U | {u}
+                );
+                k = k + 1;
+            );
+            U = delete(m, U);
+        );
+        if S#?(0_(ZZ^g)) then mons = S#(0_(ZZ^g)) else mons = {}
+    );
     if r == 0 then return apply(mons, m -> sub(m, ring D) );
-    
     W1 = W1*(transpose matrix (mons/exponents/first));
     if o.Strategy == "Polyhedra" then (
-	if r == 1 then C = convexHull W1 else C = convexHull( 2*r*W1|(-2*r*W1) );
-	C = (latticePoints C)/vector;
-	)
+        if r == 1 then C = convexHull W1 else C = convexHull( 2*r*W1|(-2*r*W1) );
+        C = (latticePoints C)/vector;
+    )
     else (
-	if r == 1 then C = (normaliz(transpose W1, "polytope"))#"gen" 
-	else C = (normaliz(transpose (2*r*W1|(-2*r*W1)), "polytope"))#"gen";
-	C = transpose C_(apply(r, i -> i));
-	C = apply(numColumns C, j -> C_j)
-	);
-    
+        if r == 1 then C = (normaliz(transpose W1, "polytope"))#"gen" 
+        else C = (normaliz(transpose (2*r*W1|(-2*r*W1)), "polytope"))#"gen";
+        C = transpose C_(apply(r, i -> i));
+        C = apply(numColumns C, j -> C_j)
+    );
     S = new MutableHashTable from apply(C, w -> w => {});
     scan(#mons, i -> S#(W1_i) = S#(W1_i)|{mons#i});
     U = new MutableHashTable from S;
-    
     nonemptyU := select(keys U, w -> #(U#w) > 0);
-    while  #nonemptyU > 0 do(
-	v = first nonemptyU;
-	m = first (U#v);
-	
-	scan(#mons, i -> (
-		u := m*mons#i;
-        	v' := v + W1_i;
-        	if ((U#?v') and all(S#v', m' -> (
-			    if u%m' =!= 0_R then true
-			    else if g > 0 then (
-				m'' := u//m';
-			    	v'' := reduceWeight(W2*(vector first exponents m''));
-			    	v'' =!= 0_(ZZ^g)
-				)
-			    else false
-			    )
-			)
-		    ) 
-		then( 
-                    S#v' = S#v'|{u};
-                    U#v' = U#v'|{u};
-		    )
-	    	)
-	    );
-	U#v = delete(m, U#v);
-	nonemptyU = select(keys U, w -> #(U#w) > 0)
-	);
+        while  #nonemptyU > 0 do(
+        v = first nonemptyU;
+        m = first (U#v);
+        
+        scan(#mons, i -> (
+            u := m*mons#i;
+            v' := v + W1_i;
+            if ((U#?v') and all(S#v', m' -> (
+                if u%m' =!= 0_R then true
+                else if g > 0 then (
+                    m'' := u//m';
+                    v'' := reduceWeight(W2*(vector first exponents m''));
+                    v'' =!= 0_(ZZ^g)
+                )
+                else false
+            ))) then ( 
+                S#v' = S#v'|{u};
+                U#v' = U#v'|{u};
+            )
+        ));
+        U#v = delete(m, U#v);
+        nonemptyU = select(keys U, w -> #(U#w) > 0)
+    );
     
     if S#?(0_(ZZ^r)) then mons = S#(0_(ZZ^r)) else mons = {};
     return apply(mons, m -> sub(m, ring D) )
-    )
+
+)
 
 
 -------------------------------------------


### PR DESCRIPTION
This commit is intended to implement a new, faster algorithm for finding the invariant generators of an elementary abelian p-group. This code is implemented within the framework of the DiagonalAction object and its respective functions.

To speed up computation speed, we utilize a method by finding the determinants of the submatricies of a given weight matrix, W. This is akin to finding the kernel of the group action. Then, we can calculate a set of seed exponent vectors that can be expanded and reduced by the order of the elementary abelian p-group to calculate the generators of the group action upon the ring, R. 

The files edited are as follows:
- AbelianGroup.m2
- AbelianGroupDoc.m2
- Invariants.m2

Below are the proposed changes:

1. Reformatted some of the AbelianGroups.m2 file with the following changes:
	* Adds comments to each method
	* Adds comments within some methods for easier parsing
	* Tabs if-statements and longer variable definitions.

2. Changes the variable the DiagonalAction objects uses to diagVariable to prevent overriding of rings that use z.

3. Creates the elementaryInvariants function (not exported) to isolate the process of calculating invariants for elementary abelian groups under a ring.
	* Contains 3 helper functions that are not exported: isZero, reduceit, and seedminimal. This method can calculate the seeds around ~10x to 100x faster than the current method.

4. Adds a method to create a diagonalAction object with an integer representing all orders (elementary abelian group).

5. Adds documentation for the usage of the new diagonalAction method option.